### PR TITLE
CI/CD improvements

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -350,10 +350,31 @@ jobs:
           CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}
         run: clojure -T:build deploy
 
+  tag-latest-snapshot:
+    name: Tag commit associated with latest snapshot version on Clojars
+    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    needs: [set-shared-outputs, clojars]
+    runs-on: ubuntu-latest
+
+    env:
+      POD_VERSION: ${{ needs.set-shared-outputs.outputs.pod_version }}
+
+    steps:
+      - name: 🛎️ Checkout
+        uses: actions/checkout@v4
+
+      - name: Tag commit
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<>"
+          git status
+          git tag -a v${{ env.POD_VERSION }} -m "This version was published to Clojars: https://clojars.org/com.github.jackdbd/pod.jackdbd.jsoup/versions/${{ env.POD_VERSION }}" --force
+          git describe
+
   github-release:
     name: GitHub release
     if: ${{ github.event_name != 'pull_request' }}
-    needs: [set-shared-outputs, build-uberjar, linux, macos, windows]
+    needs: [set-shared-outputs, build-uberjar, linux, macos, windows, clojars]
     runs-on: ubuntu-latest
     
     env:
@@ -409,7 +430,7 @@ jobs:
       # - run: ls -R
 
       # https://github.com/marketplace/actions/gh-release
-      - name: 🚀 Create GitHub release
+      - name: 🚀 Create or update GitHub release
         uses: softprops/action-gh-release@v2
         id: github_release
         with:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -46,11 +46,10 @@ jobs:
           echo "pod_version=$POD_VERSION" >> $GITHUB_OUTPUT
 
           if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-            echo "PRERELEASE=false" >> $GITHUB_ENV
+            echo "prerelease=false" >> $GITHUB_OUTPUT
           else
-            echo "PRERELEASE=true" >> $GITHUB_ENV
+            echo "prerelease=true" >> $GITHUB_OUTPUT
           fi
-          echo "prerelease=$PRERELEASE" >> $GITHUB_OUTPUT
 
       - name: Log job outputs
         run: |
@@ -329,7 +328,7 @@ jobs:
   clojars:
     name: Publish to Clojars
     if: ${{ github.event_name != 'pull_request' }}
-    # needs: [linux, macos, windows] # publish only when all tests on all platforms pass
+    needs: [linux, macos, windows] # publish only when all tests on all platforms pass
     runs-on: ubuntu-latest
 
     steps:
@@ -448,9 +447,7 @@ jobs:
         id: github_release
         with:
           body: |
-            This is a release of **${{ env.POD_NAME }}** version `${{ env.POD_VERSION }}`.
-
-            The pod is also [published as an uberjar to Clojars](https://clojars.org/com.github.jackdbd/pod.jackdbd.jsoup).
+            📦 **${{ env.POD_NAME }}** version `${{ env.POD_VERSION }}` is [available on Clojars](https://clojars.org/com.github.jackdbd/pod.jackdbd.jsoup/versions/${{ env.POD_VERSION }}).
           # draft: true
           fail_on_unmatched_files: true
           files: |

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -353,6 +353,8 @@ jobs:
   tag-latest-snapshot:
     name: Tag commit associated with latest snapshot version on Clojars
     if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
+    # Only after we have succesfully deployed to Clojars we know that the latest
+    # commit is associated with the latest snapshot version on Clojars.
     needs: [set-shared-outputs, clojars]
     runs-on: ubuntu-latest
 
@@ -374,7 +376,12 @@ jobs:
   github-release:
     name: GitHub release
     if: ${{ github.event_name != 'pull_request' }}
-    needs: [set-shared-outputs, build-uberjar, linux, macos, windows, clojars]
+    # Only after we have updated the git tag associated with the latest snapshot
+    # version we can create a GitHub release. Otherwise the commit associated
+    # with the GitHub release might be incorrect even if the git tag is correct.
+    # See the "target_commitish" parameter.
+    # https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release--parameters
+    needs: [set-shared-outputs, build-uberjar, linux, macos, windows, clojars, tag-latest-snapshot]
     runs-on: ubuntu-latest
     
     env:

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -329,7 +329,7 @@ jobs:
   clojars:
     name: Publish to Clojars
     if: ${{ github.event_name != 'pull_request' }}
-    needs: [linux, macos, windows] # publish only when all tests on all platforms pass
+    # needs: [linux, macos, windows] # publish only when all tests on all platforms pass
     runs-on: ubuntu-latest
 
     steps:
@@ -358,6 +358,9 @@ jobs:
     needs: [set-shared-outputs, clojars]
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     env:
       POD_VERSION: ${{ needs.set-shared-outputs.outputs.pod_version }}
 
@@ -365,13 +368,16 @@ jobs:
       - name: 🛎️ Checkout
         uses: actions/checkout@v4
 
-      - name: Tag commit
+      - name: Tag commit and push force it
+        # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#about-contexts
+        env:
+          BOT_NAME: snapshot-tagger[bot]
         run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<>"
-          git status
-          git tag -a v${{ env.POD_VERSION }} -m "This version was published to Clojars: https://clojars.org/com.github.jackdbd/pod.jackdbd.jsoup/versions/${{ env.POD_VERSION }}" --force
-          git describe
+          git config user.name "Snapshot Tagger Bot"
+          git config user.email "snapshot-tagger-bot@giacomodebidda.com"
+          git tag --force -a v${{ env.POD_VERSION }} -m "This version was published to Clojars: https://clojars.org/com.github.jackdbd/pod.jackdbd.jsoup/versions/${{ env.POD_VERSION }}"
+          git remote set-url origin https://${{ env.BOT_NAME }}:${{ github.token }}@github.com/${{ github.repository }}.git
+          git push --force origin v${{ env.POD_VERSION }}
 
   github-release:
     name: GitHub release

--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -352,7 +352,7 @@ jobs:
 
   tag-latest-snapshot:
     name: Tag commit associated with latest snapshot version on Clojars
-    if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name != 'pull_request' && github.ref != 'refs/heads/main' }}
     needs: [set-shared-outputs, clojars]
     runs-on: ubuntu-latest
 

--- a/bb.edn
+++ b/bb.edn
@@ -68,8 +68,13 @@
           ;; bb snapshot [patch|minor|major]
           :task (tasks/snapshot (keyword (first *command-line-args*)))}
 
-         stable {:doc "Promote the current SNAPSHOT version to stable"
-                 :task (tasks/stable)}
+         stable
+         {:doc "Promote the current SNAPSHOT version to stable"
+          :task (tasks/stable)}
+
+         sync-tags
+         {:doc "Run git fetch --force on all v*.*.*-SNAPSHOT tags"
+          :task (tasks/fetch-force-snapshot-tags)}
 
          test
          {:doc "Run all tests"

--- a/bb/tasks.bb
+++ b/bb/tasks.bb
@@ -1,7 +1,8 @@
 (ns tasks
   (:require
    [babashka.classpath :refer [get-classpath split-classpath]]
-   [babashka.process :refer [shell]]
+   [babashka.process :refer [shell sh]]
+   [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.string :as str]))
 
@@ -33,15 +34,23 @@
 
 (defn stable []
   (let [project (-> (edn/read-string (slurp "deps.edn")) :aliases :neil :project)
-        version (:version project)]
+        version (:version project)
+        result-branch (sh "git branch --show-current")
+        result-prs (sh "gh pr list --state merged --limit 1 --json title,body,number,id,mergedAt,mergeCommit,author,url")
+        m (first (json/parse-string (:out result-prs) true))
+        message (str (:title m) "\n\n" (:body m) "\n\n" (format "Merged on main with this PR: %s" (:url m)))]
     (when (not (str/includes? version "-SNAPSHOT"))
       (println "Only a SNAPSHOT version can be promoted to stable")
+      (System/exit 1))
+    (when (not= (:out result-branch) "main\n")
+      (println "Only when on the `main` branch you can promote a SNAPSHOT version to stable")
       (System/exit 1))
     (let [stable-version (str/replace (:version project) "-SNAPSHOT" "")]
       (shell (format "neil version set %s --no-tag" stable-version))
       (shell "git add deps.edn")
       (shell (format "git commit -m v%s" stable-version))
-      (shell (format "git tag -a v%s -m v%s" stable-version stable-version)))))
+      (shell ["git" "tag" "-a" (format "v%s" stable-version) "--message" message])
+      (shell (format "git push --atomic")))))
 
 (comment
   (print-classpath)

--- a/bb/tasks.bb
+++ b/bb/tasks.bb
@@ -20,18 +20,15 @@
       :major (let [snapshot-version (format "%s.%s.%s-SNAPSHOT" (inc (Integer/parseInt major)) 0 0)]
                (shell (format "neil version set %s --no-tag" snapshot-version))
                (shell "git add deps.edn")
-               (shell (format "git commit -m v%s" snapshot-version))
-               (shell (format "git tag -a v%s -m v%s" snapshot-version snapshot-version)))
+               (shell (format "git commit -m 'set version to %s'" snapshot-version)))
       :minor (let [snapshot-version (format "%s.%s.%s-SNAPSHOT" major (inc (Integer/parseInt minor)) 0)]
                (shell (format "neil version set %s --no-tag" snapshot-version))
                (shell "git add deps.edn")
-               (shell (format "git commit -m v%s" snapshot-version))
-               (shell (format "git tag -a v%s -m v%s" snapshot-version snapshot-version)))
+               (shell (format "git commit -m 'set version to %s'" snapshot-version)))
       :patch (let [snapshot-version (format "%s.%s.%s-SNAPSHOT" major minor (inc (Integer/parseInt patch)))]
                (shell (format "neil version set %s --no-tag" snapshot-version))
                (shell "git add deps.edn")
-               (shell (format "git commit -m v%s" snapshot-version))
-               (shell (format "git tag -a v%s -m v%s" snapshot-version snapshot-version)))
+               (shell (format "git commit -m 'set version to %s'" snapshot-version)))
       (shell "echo 'Usage: bb snapshot [major|minor|patch]'"))))
 
 (defn stable []

--- a/bb/tasks.bb
+++ b/bb/tasks.bb
@@ -8,7 +8,6 @@
 
 (defn print-classpath []
   (println "=== CLASSPATH BEGIN ===")
-  ;; (System/getProperty "java.class.path")
   (doseq [path (set (split-classpath (get-classpath)))]
     (println path))
   (println "=== CLASSPATH END ==="))
@@ -51,6 +50,17 @@
       (shell (format "git commit -m v%s" stable-version))
       (shell ["git" "tag" "-a" (format "v%s" stable-version) "--message" message])
       (shell (format "git push --atomic")))))
+
+(defn fetch-force-snapshot-tags []
+  (let [remote-tags (->> (sh "git" "ls-remote" "--tags" "origin")
+                         :out
+                         str/split-lines
+                         (map #(second (str/split % #"\s+")))
+                         (filter #(re-find #"v\d+\.\d+\.\d+-SNAPSHOT" %)))]
+    (doseq [tag remote-tags]
+      (let [tag-name (last (str/split tag #"/"))]
+        (println "Fetching and force updating tag:" tag-name)
+        (sh "git" "fetch" "origin" "tag" tag-name "--force")))))
 
 (comment
   (print-classpath)

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
            :dev {:extra-deps {djblue/portal {:mvn/version "0.57.3"}}
                  :extra-paths ["dev"]}
            :neil {:project {:name com.github.jackdbd/pod.jackdbd.jsoup
-                            :version "0.2.3-SNAPSHOT"}}
+                            :version "0.2.4-SNAPSHOT"}}
            :test {:extra-deps {babashka/babashka.pods {:mvn/version "0.2.0"}
                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd" :git/url "https://github.com/cognitect-labs/test-runner"}}
                   :extra-paths ["test"]

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,7 @@
            :dev {:extra-deps {djblue/portal {:mvn/version "0.57.3"}}
                  :extra-paths ["dev"]}
            :neil {:project {:name com.github.jackdbd/pod.jackdbd.jsoup
-                            :version "0.2.2"}}
+                            :version "0.2.3-SNAPSHOT"}}
            :test {:extra-deps {babashka/babashka.pods {:mvn/version "0.2.0"}
                                io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd" :git/url "https://github.com/cognitect-labs/test-runner"}}
                   :extra-paths ["test"]


### PR DESCRIPTION
This PR introduces the following Babashka tasks that can be used to manage versioning and tags.

## `bb snapshot patch|minor|major`

- Bumps a `-SNAPSHOT` version and creates a commit.
- Does **not** create a tag (the tag will be created in the CI/CD pipeline).
- Use it on a **development** branch (e.g. `canary`).

## `bb stable`

- Promotes a `-SNAPSHOT` version to a stable version, creates a tag, pushes commit and tag [atomically](https://git-scm.com/docs/git-push#Documentation/git-push.txt---no-atomic).
- Use it on a **production** branch (e.g. `main`).

## `bb sync-tags`

- Runs `git fetch --force` on all `v*.*.*-SNAPSHOT` tags.
- It's useful because since [SNAPSHOT versions might be updated](https://stackoverflow.com/a/5901460/3036129), the CI/CD pipeline has to tag the commit that (re)published a SNAPSHOT version on Clojars and `push --force` it to the remote repository.